### PR TITLE
Add API for getting meeting data with user id

### DIFF
--- a/controllers/meetingsControllers.js
+++ b/controllers/meetingsControllers.js
@@ -1,5 +1,8 @@
 const meetingService = require('../services/meetingService');
+const Meeting = require('../models/Meeting');
 const RESPONSE = require('../constants/response');
+const mongoose = require('mongoose');
+const ObjectId = mongoose.Types.ObjectId;
 
 exports.createMeeting = async (req, res, next) => {
   try {
@@ -25,13 +28,21 @@ exports.getAllFilteredMeetings = async (req, res, next) => {
   const { userId } = res.locals.userInfo;
 
   try {
-    const filteredMeetings = await meetingService.getAllFilteredMeetings(userId);
+    const result = await meetingService.getAllFilteredMeetings(userId);
+
+    if (result.error) {
+      res.status().json({
+        result: RESPONSE.FAILURE,
+        errMessage: result.error
+      })
+    }
 
     res.status(200).json({
       result: RESPONSE.OK,
-      filteredMeetings
+      filteredMeetings: result
     });
   } catch (err) {
+    console.log(err);
     next(err);
   }
 };
@@ -54,6 +65,24 @@ exports.getMeetingDetail = async (req, res, next) => {
         errMessage: RESPONSE.CAN_NOT_FIND
       });
     }
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.getMeetingByUserId = async (req, res, next) => {
+  console.log('안오나..')
+  const { userId } = req.params;
+  console.log(userId);
+  try {
+    const meeting = await Meeting.find({ "participant._id": new ObjectId(userId.toString()) });
+
+    console.log('유저 아이디로 찾아온 미팅! 없을 수도 있다.', meeting);
+
+    res.json({
+      result: RESPONSE.OK,
+      meeting
+    });
   } catch (err) {
     next(err);
   }

--- a/controllers/userControllers.js
+++ b/controllers/userControllers.js
@@ -4,14 +4,17 @@ const RESPONSE = require('../constants/response');
 
 exports.login = async (req, res, next) => {
   const token = req.get('authorization');
-  console.log(token, typeof token);
+
   if (token !== "null") {
     try {
       const { email } = jwt.verify(token, process.env.JWT_SECRET);
+
       const user = await userService.login(email);
+
       res.status(200).json({ result: 'ok', user });
     } catch (error) {
       console.error(error);
+
       res.status(401).json({ error: 'unauthorized' });
     }
 
@@ -48,7 +51,7 @@ exports.login = async (req, res, next) => {
 };
 
 exports.signup = async (req, res, next) => {
-  const { userInfo } = req.body;
+  const userInfo = req.body;
   console.log(userInfo);
 
   try {
@@ -58,9 +61,9 @@ exports.signup = async (req, res, next) => {
       { _id, email },
       process.env.JWT_SECRET
     );
-
+    console.log(user);
     res.status(201).json(
-      { result: RESPONSE.OK, token }
+      { result: RESPONSE.OK, token, user }
     );
   } catch (error) {
     res.status(500).json(
@@ -71,7 +74,7 @@ exports.signup = async (req, res, next) => {
 };
 
 exports.updatePreferPartner = async (req, res, next) => {
-  const { userId } = res.locals.userInfo;
+  const { _id: userId } = res.locals.userInfo;
   const preferredPartner = req.body;
 
   try {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "mongoose": "^5.10.13",
     "morgan": "~1.9.1",
     "pug": "2.0.0-beta11",
-    "socket.io": "^3.0.1"
+    "socket.io": "^2.3.0"
   },
   "devDependencies": {
     "dotenv": "^8.2.0",

--- a/routes/meetingsRouter.js
+++ b/routes/meetingsRouter.js
@@ -15,10 +15,16 @@ meetingsRouter.get(
   meetingsControllers.getAllFilteredMeetings
 );
 
-// READ A MEETING
+// READ A MEETING BY MEETING ID
 meetingsRouter.get(
   ROUTES.MEETING_DETAIL,
   meetingsControllers.getMeetingDetail
+);
+
+// READ A MEETING BY USER ID
+meetingsRouter.get(
+  '/user' + ROUTES.USER_DETAIL,
+  meetingsControllers.getMeetingByUserId
 );
 
 // UPDATE A MEETING (JOIN)

--- a/services/meetingService.js
+++ b/services/meetingService.js
@@ -25,10 +25,17 @@ exports.createMeeting = async ({ selectedMeeting, userId }) => {
 };
 
 exports.getAllFilteredMeetings = async userId => {
-  // 먼저 내 정보 가져오기 (선호하는 파트너 기준)
-  const { preferredPartner } = await User.findOne({ _id: userId });
+  const user = await User.findOne({ _id: userId });
 
-  const [result] = await Meeting.aggregate(
+  if (!user) {
+    return {
+      error: '유저가 없습니다! 로그인은 제대로 되었나요?'
+    }
+  }
+
+  const { preferredPartner } = user;
+
+  const [ result ] = await Meeting.aggregate(
     [
       {
         $match: {
@@ -59,19 +66,18 @@ exports.getAllFilteredMeetings = async userId => {
     ]
   );
 
-  // console.log('필터전', result.creators);
+  console.log('미팅을 생성한 모든 유저 아이디..', result.creators);
 
   const filteredCreators = [];
 
-  for (let _id of result.creators) {
+  for (let creatorId of result.creators) {
     let isMatchedPartner = false;
 
     const creator = await User.findOne(
-      { _id },
+      { _id: creatorId },
       { _id: 0 }
     );
-    // console.log(creator);
-    // console.log(preferredPartner);
+
     const { gender, birthYear, occupation } = creator;
     const {
       gender: preferredGender,
@@ -79,7 +85,6 @@ exports.getAllFilteredMeetings = async userId => {
       occupation: preferredOccupation
     } = preferredPartner;
 
-    // 크리에이터의 신상(?)과 preferredPartener의 조건을 비교하여 isMatchedPartner 인지 확인하자
     const isMatchedGender = gender === preferredGender ? true : false;
     const isMatchedOccupation = occupation === preferredOccupation ? true : false;
     let isMatchedBirthYear = false;
@@ -102,7 +107,7 @@ exports.getAllFilteredMeetings = async userId => {
         break;
     }
 
-    // console.log(isMatchedGender, isMatchedOccupation, isMatchedBirthYear);
+    console.log(isMatchedGender, isMatchedOccupation, isMatchedBirthYear);
 
     if (
       isMatchedGender &&
@@ -113,15 +118,14 @@ exports.getAllFilteredMeetings = async userId => {
     }
 
     if (isMatchedPartner) {
-      filteredCreators.push(_id);
+      filteredCreators.push(creatorId);
     }
   }
 
-  // console.log('필터후', filteredCreators);
+  console.log('선호 조건으로 필터링 된 유저 아이디..', filteredCreators);
 
   // 필터 된 아이디로 미팅 가져오기
   const filteredMeetings = [];
-
 
   // 해당 크리에이터들이 만든 미팅 정보 가져오기..
   for (let creatorId of filteredCreators) {
@@ -152,11 +156,11 @@ exports.getAllFilteredMeetings = async userId => {
         },
       ]
     );
-    // console.log(meeting[0]);
+
     filteredMeetings.push(meeting[0]);
   }
 
-  // console.log('미팅!!', filteredMeetings);
+  console.log('필터링 된 미팅들!!', filteredMeetings);
 
   return filteredMeetings;
 };

--- a/services/userService.js
+++ b/services/userService.js
@@ -4,7 +4,13 @@ exports.login = async email => {
   try {
     return await User.findOne(
       { email },
-      { history: 0, location: 0, updated_at: 0, created_at: 0, __v: 0 }
+      {
+        history: 0,
+        location: 0,
+        updated_at: 0,
+        created_at: 0,
+        __v: 0
+      }
     );
   } catch (err) {
     console.error(err);
@@ -41,10 +47,12 @@ exports.signup = async userInfo => {
 
 exports.updatePreferPartner = async (userId, preferredPartner) => {
   try {
-    return await User.update(
+    const updatedUser = await User.findOneAndUpdate(
       { _id: userId },
       { preferredPartner },
     );
+
+    return updatedUser;
   } catch (err) {
     console.error(err);
     next(err);


### PR DESCRIPTION
유저아이디를 받고, 해당 유저 아이디를 participant에 포함하고 있는 미팅을 찾아 가져오는 API를 작성하였습니다.

해당 데이터(미팅)의 존재 유무 클라이언트에서 MainMap에 입장 시, 해당 API에 요청을 보내어 유저가 이미 참여하거나 만든 미팅이 있는지 확인하고 네비게이팅 하는 분기처리에 사용됩니다.