### PR TITLE
Fix updatePreferredPartner API returns updated infomation

### DIFF
--- a/services/userService.js
+++ b/services/userService.js
@@ -64,6 +64,7 @@ exports.updatePreferPartner = async (userId, preferredPartner) => {
     const updatedUser = await User.findOneAndUpdate(
       { _id: userId },
       { preferredPartner },
+      { new: true }
     );
 
     return updatedUser;


### PR DESCRIPTION
선호하는 친구 정보 업데이트 시 업데이트 된 정보를 반환하도록 수정하였습니다. 해당 API를 수정해야 클라이언트 측에서 업데이트 된 정보를 바탕으로 선호하는 친구 정보를 올바르게 반영할 수 있습니다.